### PR TITLE
Fix pole eliminator

### DIFF
--- a/pole_eliminator/CMakeLists.txt
+++ b/pole_eliminator/CMakeLists.txt
@@ -133,7 +133,7 @@ include_directories(
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
-add_executable(pole_eliminator src/pole_eliminator.cpp)
+add_executable(pole_eliminator src/pole_eliminator.cpp src/pole_eliminator_node.cpp)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the

--- a/pole_eliminator/include/pole_eliminator/pole_eliminator.h
+++ b/pole_eliminator/include/pole_eliminator/pole_eliminator.h
@@ -1,37 +1,40 @@
-#ifndef POLE_ELIMINATOR_H
-#define POLE_ELIMINATOR_H
+#ifndef MULTI_ROBOTS_POLE_ELIMINATOR_H_
+#define MULTI_ROBOTS_POLE_ELIMINATOR_H_
 
 #include "ros/ros.h"
 #include "sensor_msgs/LaserScan.h"
 
-class Pole_Eliminator {
- public:
-    Pole_Eliminator();
-    void process();
-
+class PoleEliminator {
  private:
-    //  method
-    void laser_scan_callback(const sensor_msgs::LaserScan::ConstPtr&);
-    //  parameter
-    int hz;
-    int width;
-    int height;
-    double resolution;
-    int number_of_laser = 1080;
-    int row;
-    int column;
-    int radius_limit;
-    int pole_min_idx[4];
-    int pole_max_idx[4];
-    bool is_edge;
-    std::string laser_frame_id;
+    int HZ;
+    double ROBOT_RADIUS;
+    int MARGIN;
+    std::string LASER_FRAME;
+    static constexpr size_t MAX_LASER_SIZE = 10000;
+    ros::NodeHandle nh_;
+    ros::NodeHandle private_nh_;
+    ros::Subscriber raw_laser_scan_sub_;
+    ros::Publisher corrected_laser_scan_pub_;
 
-    //  member
-    ros::NodeHandle nh;
-    ros::NodeHandle private_nh;
-    ros::Publisher pub_laser_scan;
-    ros::Subscriber sub_laser_scan;
-    sensor_msgs::LaserScan scan_data;
-    sensor_msgs::LaserScan corrected_scan_data;
+ public:
+    PoleEliminator();
+    void process();
+    void laser_scan_callback(const sensor_msgs::LaserScanConstPtr &raw_laser);
+    void check_laser_is_in_radius(const sensor_msgs::LaserScanConstPtr &laser,
+                                  std::array<bool, MAX_LASER_SIZE> *is_in_radius_ptr);
+    void extend_is_in_radius(int margin, const size_t LASER_SIZE,
+                             std::array<bool, MAX_LASER_SIZE> *is_in_radius_ptr);
+    void check_ranges_is_in_radius(const size_t LASER_SIZE,
+                                   const std::array<bool, MAX_LASER_SIZE> &is_in_radius,
+                                   std::vector<std::pair<size_t, size_t>> *pole_ranges_ptr);
+    void register_calculation_function(
+        const sensor_msgs::LaserScanConstPtr &laser,
+        const std::vector<std::pair<size_t, size_t>> &pole_ranges,
+        std::vector<std::function<double(double)>> *linear_interpolation_funcs_ptr);
+    void calc_constant_bc(const sensor_msgs::LaserScanConstPtr &laser, size_t min_idx,
+                          size_t max_idx, double *b_ptr, double *c_ptr);
+    double ranges_index_to_angle(size_t index, double angle_min, double angle_increase);
+    double calc_range(double b, double c, double angle);
 };
-#endif  // POLE_ELIMINATOR_H
+
+#endif  // MULTI_ROBOTS_POLE_ELIMINATOR_H_

--- a/pole_eliminator/include/pole_eliminator/pole_eliminator.h
+++ b/pole_eliminator/include/pole_eliminator/pole_eliminator.h
@@ -3,18 +3,16 @@
 
 #include "ros/ros.h"
 #include "sensor_msgs/LaserScan.h"
-#include "math.h"
 
-class Pole_Eliminator
-{
+class Pole_Eliminator {
  public:
-     Pole_Eliminator();
-     void process();
+    Pole_Eliminator();
+    void process();
 
  private:
-    //method
+    //  method
     void laser_scan_callback(const sensor_msgs::LaserScan::ConstPtr&);
-    //parameter
+    //  parameter
     int hz;
     int width;
     int height;
@@ -28,13 +26,12 @@ class Pole_Eliminator
     bool is_edge;
     std::string laser_frame_id;
 
-    //member
+    //  member
     ros::NodeHandle nh;
     ros::NodeHandle private_nh;
     ros::Publisher pub_laser_scan;
     ros::Subscriber sub_laser_scan;
     sensor_msgs::LaserScan scan_data;
     sensor_msgs::LaserScan corrected_scan_data;
-
 };
-#endif//POLE_ELIMINATOR_H
+#endif  // POLE_ELIMINATOR_H

--- a/pole_eliminator/launch/pole_eliminator.launch
+++ b/pole_eliminator/launch/pole_eliminator.launch
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+    <arg name="hz" default="10" />
+    <arg name="robot_radius" default="0.30" />
+    <arg name="margin" default="15" />
+    <arg name="laser_frame" default="" />
+
+    <node pkg="pole_eliminator" type="pole_eliminator" name="pole_eliminator">
+        <remap from="scan" to="scan" />
+        <param name="HZ" value="$(arg hz)" />
+        <param name="ROBOT_RADIUS" value="$(arg robot_radius)" />
+        <param name="MARGIN" value="$(arg margin)" />
+        <param name="LASER_FRAME" value="$(arg laser_frame)" />
+    </node>
+</launch>

--- a/pole_eliminator/src/pole_eliminator.cpp
+++ b/pole_eliminator/src/pole_eliminator.cpp
@@ -32,12 +32,11 @@ void PoleEliminator::laser_scan_callback(const sensor_msgs::LaserScanConstPtr &r
 
     sensor_msgs::LaserScan corrected_laser = *raw_laser;
     if (!LASER_FRAME.empty()) corrected_laser.header.frame_id = LASER_FRAME;
-    for (size_t i = 0; i < pole_ranges.size(); i++) {
-        for (size_t j = pole_ranges[i].first + 1; j < pole_ranges[i].second; j++) {
-            double angle = ranges_index_to_angle(j, corrected_laser.angle_min,
+    for (size_t range_idx = 0; range_idx < pole_ranges.size(); range_idx++) {
+        for (size_t i = pole_ranges[range_idx].first + 1; i < pole_ranges[range_idx].second; i++) {
+            double angle = ranges_index_to_angle(i, corrected_laser.angle_min,
                                                  corrected_laser.angle_increment);
-            corrected_laser.ranges[j] = linear_interpolation_funcs[i](angle);
-            // ROS_INFO_STREAM(raw_laser->ranges[j] << " to " << corrected_laser.ranges[j]);
+            corrected_laser.ranges[i] = linear_interpolation_funcs[range_idx](angle);
         }
     }
     corrected_laser_scan_pub_.publish(corrected_laser);

--- a/pole_eliminator/src/pole_eliminator.cpp
+++ b/pole_eliminator/src/pole_eliminator.cpp
@@ -1,24 +1,21 @@
 #include "pole_eliminator/pole_eliminator.h"
 
-Pole_Eliminator::Pole_Eliminator():private_nh("~")
-{
-    //parameter
-    private_nh.param("hz",hz,{40});
-    private_nh.param("width",width,{5});
-    private_nh.param("height",height,{5});
-    private_nh.param("resolution",resolution,{0.05});
-    private_nh.param("radius_limit",radius_limit,{49});
-    private_nh.param("laser_frame_id",laser_frame_id,std::string("laser"));
+Pole_Eliminator::Pole_Eliminator() : private_nh("~") {
+    //  parameter
+    private_nh.param("hz", hz, {40});
+    private_nh.param("width", width, {5});
+    private_nh.param("height", height, {5});
+    private_nh.param("resolution", resolution, {0.05});
+    private_nh.param("radius_limit", radius_limit, {49});
+    private_nh.param("laser_frame_id", laser_frame_id, std::string("laser"));
 
-    //subscriber
-    sub_laser_scan = nh.subscribe("scan",10, &Pole_Eliminator::laser_scan_callback,this);
-    //publisher
+    //  subscriber
+    sub_laser_scan = nh.subscribe("scan", 10, &Pole_Eliminator::laser_scan_callback, this);
+    //  publisher
     pub_laser_scan = nh.advertise<sensor_msgs::LaserScan>("corrected_scan", 10);
 }
 
-
-void Pole_Eliminator::laser_scan_callback(const sensor_msgs::LaserScan::ConstPtr& msg)
-{
+void Pole_Eliminator::laser_scan_callback(const sensor_msgs::LaserScan::ConstPtr& msg) {
     scan_data = *msg;
     scan_data.header.frame_id = laser_frame_id;
     ROS_INFO_STREAM("recieved data size : " << msg->ranges.size());
@@ -34,111 +31,126 @@ void Pole_Eliminator::laser_scan_callback(const sensor_msgs::LaserScan::ConstPtr
     static double scan_intensities_buffer[1081];
     int counter = 0;
 
-    for(size_t i=0;i<4;i++){
-       pole_min_idx[i] = 0;
-       pole_max_idx[i] = 0;
+    for (size_t i = 0; i < 4; i++) {
+        pole_min_idx[i] = 0;
+        pole_max_idx[i] = 0;
     }
 
     for (size_t i = 0; i < msg->ranges.size(); i++) {
-        if(counter == 4){
-           if(i < 1000){
-              counter = 5;
-           }
-           break;
+        if (counter == 4) {
+            if (i < 1000) {
+                counter = 5;
+            }
+            break;
         }
         if (scan_data.ranges[i] < dist && !f) {
             f = true;
             ROS_INFO_STREAM("from " << counter << ", " << i);
-            if(i==0)
-               pole_min_idx[counter] = i;
+            if (i == 0)
+                pole_min_idx[counter] = i;
             else
-               pole_min_idx[counter] = i-20;
-            if(i > 1000){
-               pole_min_idx[counter] = i-20;
-               pole_max_idx[counter] = 1081;
+                pole_min_idx[counter] = i - 20;
+            if (i > 1000) {
+                pole_min_idx[counter] = i - 20;
+                pole_max_idx[counter] = 1081;
             }
         }
         if (scan_data.ranges[i] >= dist && f) {
             f = false;
             ROS_INFO_STREAM("     " << counter << ", " << i << " end");
-            pole_max_idx[counter] = i+20;
+            pole_max_idx[counter] = i + 20;
         }
 
-        if((counter==0 || counter == 3) && pole_max_idx[counter] - pole_min_idx[counter] > 30)
+        if ((counter == 0 || counter == 3) && pole_max_idx[counter] - pole_min_idx[counter] > 30)
             counter++;
-        if((counter==1 || counter == 2) && pole_max_idx[counter] - pole_min_idx[counter] > 50)
+        if ((counter == 1 || counter == 2) && pole_max_idx[counter] - pole_min_idx[counter] > 50)
             counter++;
     }
 
     ROS_INFO_STREAM("Auto detector");
-    for(size_t i=0;i<4;i++){
+    for (size_t i = 0; i < 4; i++) {
         ROS_INFO_STREAM("from " << pole_min_idx[i]);
         ROS_INFO_STREAM("     " << pole_max_idx[i] << " end");
     }
     ROS_INFO_STREAM("counter=" << counter);
-    if(counter == 4 && pole_max_idx[0] < pole_min_idx[1]){
+    if (counter == 4 && pole_max_idx[0] < pole_min_idx[1]) {
         counter = 0;
-        point_min[0] = scan_data.ranges[pole_min_idx[counter]]*cos((-45.0+pole_min_idx[counter]*0.25)*M_PI/180.0);
-        point_min[1] = scan_data.ranges[pole_min_idx[counter]]*sin((-45.0+pole_min_idx[counter]*0.25)*M_PI/180.0);
-        point_max[0] = scan_data.ranges[pole_max_idx[counter]]*cos((-45.0+pole_max_idx[counter]*0.25)*M_PI/180.0);
-        point_max[1] = scan_data.ranges[pole_max_idx[counter]]*sin((-45.0+pole_max_idx[counter]*0.25)*M_PI/180.0);
-        ROS_INFO_STREAM("point_min " << point_min[0] << ", " << point_min[1] << ", " << sqrt(pow(point_min[0], 2.0) + pow(point_min[1], 2.0)));
-        ROS_INFO_STREAM("point_max " << point_max[0] << ", " << point_max[1] << ", " << sqrt(pow(point_max[0], 2.0) + pow(point_max[1], 2.0)));
-        for(size_t i=0;i<msg->ranges.size();i++){
-            if(pole_min_idx[counter] <= i && i <= pole_max_idx[counter]){
-                b=(point_min[1]-point_max[1])/(point_min[0]-point_max[0]);
-                c=(point_max[0]*point_min[1]-point_min[0]*point_max[1])/(point_max[0]-point_min[0]);
-                if(-45.0+i*0.25 == 0.0 || -45.0+i*0.25 == 180.0){
-                    cross_point[0] = -c/b;
+        point_min[0] = scan_data.ranges[pole_min_idx[counter]] *
+                       cos((-45.0 + pole_min_idx[counter] * 0.25) * M_PI / 180.0);
+        point_min[1] = scan_data.ranges[pole_min_idx[counter]] *
+                       sin((-45.0 + pole_min_idx[counter] * 0.25) * M_PI / 180.0);
+        point_max[0] = scan_data.ranges[pole_max_idx[counter]] *
+                       cos((-45.0 + pole_max_idx[counter] * 0.25) * M_PI / 180.0);
+        point_max[1] = scan_data.ranges[pole_max_idx[counter]] *
+                       sin((-45.0 + pole_max_idx[counter] * 0.25) * M_PI / 180.0);
+        ROS_INFO_STREAM("point_min " << point_min[0] << ", " << point_min[1] << ", "
+                                     << sqrt(pow(point_min[0], 2.0) + pow(point_min[1], 2.0)));
+        ROS_INFO_STREAM("point_max " << point_max[0] << ", " << point_max[1] << ", "
+                                     << sqrt(pow(point_max[0], 2.0) + pow(point_max[1], 2.0)));
+        for (size_t i = 0; i < msg->ranges.size(); i++) {
+            if (pole_min_idx[counter] <= i && i <= pole_max_idx[counter]) {
+                b = (point_min[1] - point_max[1]) / (point_min[0] - point_max[0]);
+                c = (point_max[0] * point_min[1] - point_min[0] * point_max[1]) /
+                    (point_max[0] - point_min[0]);
+                if (-45.0 + i * 0.25 == 0.0 || -45.0 + i * 0.25 == 180.0) {
+                    cross_point[0] = -c / b;
                     cross_point[1] = 0.0;
-                }else if(-45.0+i*0.25 == 90.0 || -45.0+i*0.25 == 270.0){
+                } else if (-45.0 + i * 0.25 == 90.0 || -45.0 + i * 0.25 == 270.0) {
                     cross_point[0] = 0.0;
                     cross_point[1] = c;
-                }else{
-                    a = tan((-45.0+i*0.25)*M_PI/180.0);
-                    //ROS_INFO_STREAM("a, theta=" << a << ", " << -45.0+i*0.25);
-                    cross_point[0] = c/(a-b);
-                    cross_point[1] = a*c/(a-b);
+                } else {
+                    a = tan((-45.0 + i * 0.25) * M_PI / 180.0);
+                    // ROS_INFO_STREAM("a, theta=" << a << ", " << -45.0+i*0.25);
+                    cross_point[0] = c / (a - b);
+                    cross_point[1] = a * c / (a - b);
                 }
 
-                //ROS_INFO_STREAM("cross_point " << cross_point[0] << ", " << cross_point[1]);
-                if(counter == 0){
+                // ROS_INFO_STREAM("cross_point " << cross_point[0] << ", " << cross_point[1]);
+                if (counter == 0) {
                     scan_data.ranges[i] = scan_data.ranges[pole_max_idx[counter]];
                     scan_data.intensities[i] = scan_data.intensities[pole_max_idx[counter]];
-                }else if(counter == 3){
+                } else if (counter == 3) {
                     scan_data.ranges[i] = scan_data.ranges[pole_min_idx[counter]];
                     scan_data.intensities[i] = scan_data.intensities[pole_min_idx[counter]];
-                }else{
-                    scan_data.ranges[i] = sqrt(pow(cross_point[0],2.0)+pow(cross_point[1],2.0));
+                } else {
+                    scan_data.ranges[i] = sqrt(pow(cross_point[0], 2.0) + pow(cross_point[1], 2.0));
                     scan_data.intensities[i] = scan_data.intensities[pole_min_idx[counter]];
                 }
 
-                //ROS_INFO_STREAM("Log a b c " << a << ", " << b << ", " << c);
+                // ROS_INFO_STREAM("Log a b c " << a << ", " << b << ", " << c);
                 ROS_INFO_STREAM("scan_data.ranges " << scan_data.ranges[i]);
 
-            }else if(pole_max_idx[counter] < i){
+            } else if (pole_max_idx[counter] < i) {
                 counter++;
-                point_min[0] = scan_data.ranges[pole_min_idx[counter]]*cos((-45.0+pole_min_idx[counter]*0.25)*M_PI/180.0);
-                point_min[1] = scan_data.ranges[pole_min_idx[counter]]*sin((-45.0+pole_min_idx[counter]*0.25)*M_PI/180.0);
-                point_max[0] = scan_data.ranges[pole_max_idx[counter]]*cos((-45.0+pole_max_idx[counter]*0.25)*M_PI/180.0);
-                point_max[1] = scan_data.ranges[pole_max_idx[counter]]*sin((-45.0+pole_max_idx[counter]*0.25)*M_PI/180.0);
-                ROS_INFO_STREAM("point_min " << point_min[0] << ", " << point_min[1] << ", " << sqrt(pow(point_min[0], 2.0) + pow(point_min[1], 2.0)));
-                ROS_INFO_STREAM("point_max " << point_max[0] << ", " << point_max[1] << ", " << sqrt(pow(point_max[0], 2.0) + pow(point_max[1], 2.0)));
+                point_min[0] = scan_data.ranges[pole_min_idx[counter]] *
+                               cos((-45.0 + pole_min_idx[counter] * 0.25) * M_PI / 180.0);
+                point_min[1] = scan_data.ranges[pole_min_idx[counter]] *
+                               sin((-45.0 + pole_min_idx[counter] * 0.25) * M_PI / 180.0);
+                point_max[0] = scan_data.ranges[pole_max_idx[counter]] *
+                               cos((-45.0 + pole_max_idx[counter] * 0.25) * M_PI / 180.0);
+                point_max[1] = scan_data.ranges[pole_max_idx[counter]] *
+                               sin((-45.0 + pole_max_idx[counter] * 0.25) * M_PI / 180.0);
+                ROS_INFO_STREAM("point_min "
+                                << point_min[0] << ", " << point_min[1] << ", "
+                                << sqrt(pow(point_min[0], 2.0) + pow(point_min[1], 2.0)));
+                ROS_INFO_STREAM("point_max "
+                                << point_max[0] << ", " << point_max[1] << ", "
+                                << sqrt(pow(point_max[0], 2.0) + pow(point_max[1], 2.0)));
             }
             scan_ranges_buffer[i] = scan_data.ranges[i];
             scan_intensities_buffer[i] = scan_data.intensities[i];
         }
-    }else{
-       for(size_t i=0;i<msg->ranges.size();i++){
-          scan_data.ranges[i] = scan_ranges_buffer[i];
-          scan_data.intensities[i] = scan_intensities_buffer[i];
-       }
-       if(counter > 4){
-          ROS_WARN_STREAM("Counter error");
-       }
-       if(pole_max_idx[0] >= pole_min_idx[1]){
-          ROS_WARN_STREAM("Pole detection error");
-       }
+    } else {
+        for (size_t i = 0; i < msg->ranges.size(); i++) {
+            scan_data.ranges[i] = scan_ranges_buffer[i];
+            scan_data.intensities[i] = scan_intensities_buffer[i];
+        }
+        if (counter > 4) {
+            ROS_WARN_STREAM("Counter error");
+        }
+        if (pole_max_idx[0] >= pole_min_idx[1]) {
+            ROS_WARN_STREAM("Pole detection error");
+        }
     }
 
     ROS_INFO_STREAM("Received");
@@ -146,24 +158,17 @@ void Pole_Eliminator::laser_scan_callback(const sensor_msgs::LaserScan::ConstPtr
     pub_laser_scan.publish(corrected_scan_data);
 }
 
-
-
-
-void Pole_Eliminator::process()
-{
+void Pole_Eliminator::process() {
     ros::Rate loop_rate(hz);
-    while(ros::ok())
-    {
+    while (ros::ok()) {
         ros::spinOnce();
         loop_rate.sleep();
     }
 }
 
-int main (int argc, char **argv)
-{
-    ros::init(argc,argv,"pole_eliminator");
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "pole_eliminator");
     Pole_Eliminator pole_eliminator;
     pole_eliminator.process();
     return 0;
 }
-

--- a/pole_eliminator/src/pole_eliminator.cpp
+++ b/pole_eliminator/src/pole_eliminator.cpp
@@ -33,7 +33,7 @@ void PoleEliminator::laser_scan_callback(const sensor_msgs::LaserScanConstPtr &r
     sensor_msgs::LaserScan corrected_laser = *raw_laser;
     if (!LASER_FRAME.empty()) corrected_laser.header.frame_id = LASER_FRAME;
     for (size_t range_idx = 0; range_idx < pole_ranges.size(); range_idx++) {
-        for (size_t i = pole_ranges[range_idx].first + 1; i < pole_ranges[range_idx].second; i++) {
+        for (size_t i = pole_ranges[range_idx].first; i < pole_ranges[range_idx].second; i++) {
             double angle = ranges_index_to_angle(i, corrected_laser.angle_min,
                                                  corrected_laser.angle_increment);
             corrected_laser.ranges[i] = linear_interpolation_funcs[range_idx](angle);

--- a/pole_eliminator/src/pole_eliminator_node.cpp
+++ b/pole_eliminator/src/pole_eliminator_node.cpp
@@ -1,0 +1,8 @@
+#include "pole_eliminator/pole_eliminator.h"
+
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "pole_eliminator");
+    PoleEliminator pole_eliminator;
+    pole_eliminator.process();
+    return 0;
+}


### PR DESCRIPTION
PoleEliminatorが落ちる現象を以下のバグで確認しました。テストしたところ直線の方程式の変数a, bが同じ値になり、0除算が起きていたために落ちていたようなので、tanの角度のためのしきい値判断にESPを加えて、余裕をもたせました。
`hornet:~/bagfiles/multi_robots/test_pole_eliminator/die_pole_eliminator_process.bag`

また、CounterErrorが出ないようにロボット半径内のセンサ値（ノイズと思われるのも含めて）に対して、全て補正をかけるようにしました。

残りは、一通り関数化しただけになっています。確認よろしくおねがいします。

p.s. 高砂さんにmasterのコンフリクトの直し方を木曜に教えるので、マージするのはその後にお願いします。←Done